### PR TITLE
Update the optional children type definition in jsx.d.ts

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -165,7 +165,7 @@ interface HtmxBuiltinExtensions {
  */
 interface HtmxAttributes {
 	/** @ignore For React compatibility only. */
-	children?: {};
+	children?: {} | null;
 	/** @ignore For React compatibility only. */
 	key?: {};
 	/**


### PR DESCRIPTION
Added null to the possible types of the optional children property on the HtmxAttributes interface